### PR TITLE
fix(keywords): extend the list of restricted names, with a test

### DIFF
--- a/libninja/tests/basic/main.rs
+++ b/libninja/tests/basic/main.rs
@@ -13,6 +13,7 @@ use ln_core::{OutputConfig, PackageConfig};
 
 const BASIC: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/spec/basic.yaml");
 const RECURLY: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/spec/recurly.yaml");
+const KEYWORDS: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/spec/keywords.yaml");
 
 const EXAMPLE: &str = include_str!("link_create_token.rs");
 
@@ -69,6 +70,26 @@ pub fn test_build_full_library_recurly() -> Result<()> {
         language: Language::Rust,
         config: Default::default(),
         github_repo: Some("libninjacom/recurly".to_string()),
+        version: None,
+        derive: vec![],
+    };
+    generate_library(spec, opts)
+}
+
+#[test]
+pub fn test_keywords_schema() -> Result<()> {
+    let yaml = File::open(KEYWORDS).unwrap();
+    let temp = tempfile::tempdir()?;
+
+    let spec: OpenAPI = serde_yaml::from_reader(yaml).unwrap();
+    let opts = OutputConfig {
+        dest_path: temp.path().to_path_buf(),
+        build_examples: false,
+        package_name: "keywords".to_string(),
+        service_name: "Keywords".to_string(),
+        language: Language::Rust,
+        config: Default::default(),
+        github_repo: Some("libninjacom/test".to_string()),
         version: None,
         derive: vec![],
     };

--- a/libninja/tests/spec/keywords.yaml
+++ b/libninja/tests/spec/keywords.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.1
+servers:
+    - url: "{scheme}://example.com/keywords"
+      variables:
+          scheme:
+              description: "This OpenAPI schema names fields after Rust keywords."
+              enum:
+                  - "https"
+                  - "http"
+              default: "https"
+info:
+    description: >-
+        This api uses Rust keywords in dangerous places.
+    version: 1.0.0
+    title: Rust keyword test
+paths:
+    /:
+        get:
+            operationId: fetch-keywords
+            summary: Fetch keywords
+            responses:
+                "200":
+                    description: Returns a struct with fields named after rust keywords.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/dangerNoodle"
+components:
+    schemas:
+        dangerNoodle:
+            type: object
+            properties:
+                async:
+                    type: boolean
+                enum:
+                    type: string
+                final:
+                    type: boolean
+                match:
+                    type: integer
+                mut:
+                    type: boolean
+                self:
+                    type: string
+                type:
+                    type: boolean
+                use:
+                    type: boolean

--- a/mir_rust/src/lib.rs
+++ b/mir_rust/src/lib.rs
@@ -5,11 +5,11 @@ use regex::{Captures, Regex};
 
 use mir::{Doc, Ident, Literal, ParamKey, Visibility};
 
-mod file;
 mod class;
-mod import;
-mod function;
 mod r#enum;
+mod file;
+mod function;
+mod import;
 
 /// Use this for codegen structs: Function, Class, etc.
 pub trait ToRustCode {
@@ -39,7 +39,6 @@ impl ToRustCode for Visibility {
         }
     }
 }
-
 
 impl ToRustCode for Option<Doc> {
     fn to_rust_code(self) -> TokenStream {
@@ -71,7 +70,6 @@ impl ToRustCode for ParamKey {
         }
     }
 }
-
 
 pub trait ToRustIdent {
     fn to_rust_struct(&self) -> Ident;
@@ -155,7 +153,10 @@ fn sanitize_struct(s: impl AsRef<str>) -> Ident {
 }
 
 pub fn is_restricted(s: &str) -> bool {
-    ["type", "use", "ref", "self", "match", "final"].contains(&s)
+    [
+        "async", "enum", "final", "match", "mut", "ref", "self", "type", "use",
+    ]
+    .contains(&s)
 }
 
 fn assert_valid_ident(s: &str, original: &str) {
@@ -177,7 +178,10 @@ mod tests {
     #[test]
     fn test_filename() {
         let s = "SdAddress.contractor1099";
-        assert_eq!(String::from(s).to_rust_ident().0, "sd_address_contractor1099");
+        assert_eq!(
+            String::from(s).to_rust_ident().0,
+            "sd_address_contractor1099"
+        );
         assert_eq!(sanitize_filename(s), "sd_address_contractor1099");
     }
 }


### PR DESCRIPTION
I observed that the list of restricted words didn't cover some attractive words when I attempted to generate a Rust client for a schema that used keywords like `async` as field names.

- Extended the list of names in `is_restricted()`.
- Added a short yaml schema that uses all of the restricted words as field names. Put this fixture to work in a test, to ensure no regressions.

The list is undoubtedly incomplete, but there is a very clear place to add new ones (thank you!) and now a test to validate it.